### PR TITLE
Don't require the whole of hogan.js in templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var hogan = require('hogan.js'),
 var filenamePattern = /\.(html|hogan|hg|mustache|ms)$/
 
 var wrap = function(template) {
-    return 'module.exports=(function() {var Hogan = require(\'hogan.js\');var template = new Hogan.Template(' + template + ');return function(data) {return template.render(data)}}());'
+    return 'module.exports = new (require(\'hogan.js/lib/template\').Template)(' + template + ').render;'
 }
 
 module.exports = function(file) {


### PR DESCRIPTION
Changed it so the generated template modules only require Hogan's [template module](https://github.com/twitter/hogan.js/blob/master/lib/template.js) (instead of the whole [hogan.js package](https://github.com/twitter/hogan.js/blob/master/lib/hogan.js)).

This basically excludes the whole [compiler module](https://github.com/twitter/hogan.js/blob/master/lib/compiler.js), which isn't needed on the frontend.
